### PR TITLE
Docker config for getting started quickly

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Opentheso is a web-based thesaurus management tool dedicated to the management o
 
 OpenTheso is used by a network of 39 research libraries (FRANTIQ. Archaeology, 32 000 concepts. Contact : Blandine Nouvel), research units (Zoomatia, archaelogical research project), les Hospices civils de Lyon (medicine, 60000 concepts), l’Institut des Sciences de l’Homme (part of Rameau vocabulary)…
 
+## Quick Start
+
+Docker Images and a Docker Compose configuration are provided to enable you to get started quickly, see our: [Docker README.md](https://github.com/miledrousset/opentheso/tree/master/src).
+
 ## License
 
 OpenTheso is released under the terms of the [CeCILL_C](http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.html) license, fully compatible with the GNU GPL.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM tomcat:9.0
+MAINTAINER Evolved Binary
+
+COPY opentheso-4.5.9.war /usr/local/tomcat/webapps/opentheso.war
+
+RUN mkdir /usr/local/tomcat/webapps/opentheso \
+	&& unzip -d /usr/local/tomcat/webapps/opentheso/ /usr/local/tomcat/webapps/opentheso.war \
+	&& mkdir -p /var/www/images/resize
+
+
+# Modify the config for Opentheso
+COPY preferences.properties /usr/local/tomcat/webapps/opentheso/WEB-INF/classes/
+COPY hikari.properties /usr/local/tomcat/webapps/opentheso/WEB-INF/classes/

--- a/docker/Dockerfile-postgres
+++ b/docker/Dockerfile-postgres
@@ -1,0 +1,7 @@
+FROM postgres
+MAINTAINER Evolved Binary
+
+# Copy in the Opentheso database setup script
+ADD https://raw.githubusercontent.com/miledrousset/opentheso/master/src/main/resources/install/opentheso_current.sql /docker-entrypoint-initdb.d/
+
+RUN chmod 744 /docker-entrypoint-initdb.d/opentheso_current.sql

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,56 @@
+# Building the Docker Image
+
+The configuration for two Docker Images are provided; one image for Opentheso itself, and the other for a Postgres database which holds the Opentheso data. 
+
+```
+docker image build -t miledrousset/opentheso-postgres -f Dockerfile-postgres .
+
+docker image build -t miledrousset/opentheso .
+```
+
+
+# Running the Docker Containers
+
+There are two options for running the Docker Containers:
+1. Using Docker Compose to manage the containers for you
+2. Using Docker directly to start each container
+
+Pre-requisites:
+1. Docker
+2. Place a copy of `opentheso-4.5.9.war` in the `opentheso/docker` directory.
+
+
+## Running via Docker Compose
+
+Simply execute:
+
+```
+cd opentheso/docker
+
+docker compose up
+```
+
+## Running directly with Docker
+
+A Docker Container for the Opentheso Posgres database must be started before starting a container for Opentheso itself.
+
+```
+cd opentheso/docker
+
+docker run --name opentheso-db --volume opentheso-pgdata:/pgdata --env POSTGRES_USER=opentheso --env POSTGRES_PASSWORD=opentheso --env PGDATA=/pgdata miledrousset/opentheso-postgres
+
+docker run --name opentheso --link opentheso-db --publish 8080:8080 -it miledrousset/opentheso
+```
+
+## Accessing Opentheso
+
+Once the Docker Containers are running, you can access Opentheso in a web-browser by visiting: http://localhost:8080/opentheso
+
+
+# Docker Volumes
+
+The docker volume `opentheso-pgdata` stores the database, if you want to start with a clean slate you can remove the volume and it will be re-created. To remove the volume just run:
+
+```
+docker volume rm opentheso-pgdata
+```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.1'
+
+services:
+
+  opentheso:
+    image: miledrousset/opentheso
+    restart: always
+    depends_on:
+      - opentheso-db
+    ports:
+      - 8080:8080
+
+  opentheso-db:
+    image: miledrouset/opentheso-postgres
+    restart: always
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: opentheso
+      POSTGRES_PASSWORD: opentheso
+      PGDATA: /pgdata
+    volumes:
+      - type: volume
+        source: opentheso-pgdata
+        target: /pgdata
+
+volumes:
+  opentheso-pgdata:
+    external: false

--- a/docker/hikari.properties
+++ b/docker/hikari.properties
@@ -1,0 +1,13 @@
+minimumIdle=1
+autoCommit=true
+setMaximumPoolSize=1000
+idleTimeout=30000
+connectionTimeout=30000
+connectionTestQuery=SELECT 1
+dataSourceClassName=org.postgresql.ds.PGSimpleDataSource
+
+dataSource.serverName=opentheso-db
+dataSource.serverPort=5432
+dataSource.user=opentheso
+dataSource.password=opentheso
+dataSource.databaseName=opentheso

--- a/docker/preferences.properties
+++ b/docker/preferences.properties
@@ -1,0 +1,14 @@
+#Preferred language
+workLanguage=en
+
+#l'identifiant du th\u00e9saurus par d\u00e9faut \u00e0 charger
+defaultThesaurusId=TH_1
+
+
+#Serveur de mail pour les alertes du module candidats
+protocolMail=smtp
+hostMail=smtp.mom.fr
+portMail=25
+authMail=false
+mailFrom=opentheso@mom.fr
+transportMail=smtp


### PR DESCRIPTION
This provides the necessary Docker files and Docker Compose config, so that getting started with Opentheso can be as simple as:

```
git clone https://github.com/miledrousset/opentheso.git
cd opentheso/docker

wget https://github.com/miledrousset/opentheso/releases/download/4.5.9/opentheso-4.5.9.war

docker image build -t miledrousset/opentheso-postgres -f Dockerfile-postgres .
docker image build -t miledrousset/opentheso .

docker compose up
```

After which both Postgres and Opentheso are now running in Docker and the user can just access http://localhost:8080/opentheso

I have supplied documentation also in the `docker/README.md` file. Apologies as my French language skills are not good enough to help translate the instructions into French.

---
This could be improved further in future if desired by:
1. Fixing the Maven build. At present `mvn package` fails.
2. Adding the fabric8 Docker Maven Plugin to the `pom.xml` to help generate the Dockerfiles and Compose config.
3. For each release, Publish the Docker images to Docker Hub so the user does not need to build anything themselves, and could just run the single `docker compose up` command.